### PR TITLE
Update Indra import statements to latest version

### DIFF
--- a/BEL to Natural Language.ipynb
+++ b/BEL to Natural Language.ipynb
@@ -36,8 +36,8 @@
     "import ndex2\n",
     "import pybel\n",
     "\n",
-    "from indra.assemblers.english_assembler import EnglishAssembler\n",
-    "from indra.sources.bel.bel_api import process_pybel_graph\n",
+    "from indra.assemblers.english import EnglishAssembler\n",
+    "from indra.sources.bel.api import process_pybel_graph\n",
     "\n",
     "from pybel.examples import sialic_acid_graph\n",
     "from pybel_tools.visualization import to_jupyter"


### PR DESCRIPTION
It turns out that 
```python
from indra.assemblers.english_assembler import EnglishAssembler
from indra.sources.bel.bel_api import process_pybel_graph
```
are no longer the right way to import `EnglishAssembler` and `process_pybel_graph` in the latest version of indra.  Instead, this will work:

```python
from indra.assemblers.english import EnglishAssembler
from indra.sources.bel.api import process_pybel_graph
```